### PR TITLE
Add: Angular Randomisation Test

### DIFF
--- a/examples/T2-hypothesis-testing.ipynb
+++ b/examples/T2-hypothesis-testing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -76,16 +76,16 @@
       "\n",
       "Test Statistics  (ρ | z-score): 0.82522 | 5.44787\n",
       "P-value: 0.00185 **\n",
-      "Bootstrap P-value: 0.00770 **\n"
+      "Bootstrap P-value: 0.00820 **\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "RayleighTestResult(r=np.float64(0.8252177448200448), z=np.float64(5.4478746109270455), pval=np.float64(0.0018516375077209267), bootstrap_pval=np.float64(0.0077))"
+       "RayleighTestResult(r=np.float64(0.8252177448200448), z=np.float64(5.4478746109270455), pval=np.float64(0.0018516375077209267), bootstrap_pval=np.float64(0.0082))"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -247,7 +247,7 @@
        "ChiSquareTestResult(chi2=np.float64(66.54285714285714), pval=np.float64(5.518107289173823e-10))"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -479,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -555,7 +555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -629,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -680,36 +680,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'watermark'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[42], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mget_ipython\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_line_magic\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mload_ext\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mwatermark\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m get_ipython()\u001b[38;5;241m.\u001b[39mrun_line_magic(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mwatermark\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m--time --date --timezone --updated --python --iversions --watermark\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:2482\u001b[0m, in \u001b[0;36mInteractiveShell.run_line_magic\u001b[0;34m(self, magic_name, line, _stack_depth)\u001b[0m\n\u001b[1;32m   2480\u001b[0m     kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mlocal_ns\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_local_scope(stack_depth)\n\u001b[1;32m   2481\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbuiltin_trap:\n\u001b[0;32m-> 2482\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2484\u001b[0m \u001b[38;5;66;03m# The code below prevents the output from being displayed\u001b[39;00m\n\u001b[1;32m   2485\u001b[0m \u001b[38;5;66;03m# when using magics with decorator @output_can_be_silenced\u001b[39;00m\n\u001b[1;32m   2486\u001b[0m \u001b[38;5;66;03m# when the last Python token in the expression is a ';'.\u001b[39;00m\n\u001b[1;32m   2487\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(fn, magic\u001b[38;5;241m.\u001b[39mMAGIC_OUTPUT_CAN_BE_SILENCED, \u001b[38;5;28;01mFalse\u001b[39;00m):\n",
-      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/magics/extension.py:33\u001b[0m, in \u001b[0;36mExtensionMagics.load_ext\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m module_str:\n\u001b[1;32m     32\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m UsageError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mMissing module name.\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m---> 33\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshell\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mextension_manager\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload_extension\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m res \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124malready loaded\u001b[39m\u001b[38;5;124m'\u001b[39m:\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m extension is already loaded. To reload it, use:\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m module_str)\n",
-      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/extensions.py:62\u001b[0m, in \u001b[0;36mExtensionManager.load_extension\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     55\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Load an IPython extension by its module name.\u001b[39;00m\n\u001b[1;32m     56\u001b[0m \n\u001b[1;32m     57\u001b[0m \u001b[38;5;124;03mReturns the string \"already loaded\" if the extension is already loaded,\u001b[39;00m\n\u001b[1;32m     58\u001b[0m \u001b[38;5;124;03m\"no load function\" if the module doesn't have a load_ipython_extension\u001b[39;00m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;124;03mfunction, or None if it succeeded.\u001b[39;00m\n\u001b[1;32m     60\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     61\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 62\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_load_extension\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     63\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mModuleNotFoundError\u001b[39;00m:\n\u001b[1;32m     64\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m module_str \u001b[38;5;129;01min\u001b[39;00m BUILTINS_EXTS:\n",
-      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/extensions.py:77\u001b[0m, in \u001b[0;36mExtensionManager._load_extension\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     75\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshell\u001b[38;5;241m.\u001b[39mbuiltin_trap:\n\u001b[1;32m     76\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m module_str \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m sys\u001b[38;5;241m.\u001b[39mmodules:\n\u001b[0;32m---> 77\u001b[0m         mod \u001b[38;5;241m=\u001b[39m \u001b[43mimport_module\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     78\u001b[0m     mod \u001b[38;5;241m=\u001b[39m sys\u001b[38;5;241m.\u001b[39mmodules[module_str]\n\u001b[1;32m     79\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_call_load_ipython_extension(mod):\n",
-      "File \u001b[0;32m~/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90\u001b[0m, in \u001b[0;36mimport_module\u001b[0;34m(name, package)\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[38;5;28;01mbreak\u001b[39;00m\n\u001b[1;32m     89\u001b[0m         level \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[0;32m---> 90\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_bootstrap\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_gcd_import\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m[\u001b[49m\u001b[43mlevel\u001b[49m\u001b[43m:\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpackage\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlevel\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m<frozen importlib._bootstrap>:1387\u001b[0m, in \u001b[0;36m_gcd_import\u001b[0;34m(name, package, level)\u001b[0m\n",
-      "File \u001b[0;32m<frozen importlib._bootstrap>:1360\u001b[0m, in \u001b[0;36m_find_and_load\u001b[0;34m(name, import_)\u001b[0m\n",
-      "File \u001b[0;32m<frozen importlib._bootstrap>:1324\u001b[0m, in \u001b[0;36m_find_and_load_unlocked\u001b[0;34m(name, import_)\u001b[0m\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'watermark'"
-     ]
-    }
-   ],
-   "source": [
-    "%load_ext watermark\n",
-    "%watermark --time --date --timezone --updated --python --iversions --watermark"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -718,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -731,7 +701,7 @@
       "HA: The two samples do not come from the same population.\n",
       "\n",
       "Observed Test Statistic: 105.98051\n",
-      "P-value: 0.59141 \n"
+      "P-value: 0.57343 \n"
      ]
     }
    ],
@@ -743,6 +713,34 @@
     "c1 = Circular(data=d[d[\"sample\"] == 2][\"θ\"].values)\n",
     "\n",
     "T, pval = angular_randomisation_test(circs=[c0, c1], n_simulation=1000, verbose=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last updated: 2025-02-14 15:14:53CET\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.12.7\n",
+      "IPython version      : 8.32.0\n",
+      "\n",
+      "numpy      : 2.2.3\n",
+      "pycircstat2: 0.1.8\n",
+      "\n",
+      "Watermark: 2.5.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext watermark\n",
+    "%watermark --time --date --timezone --updated --python --iversions --watermark"
    ]
   },
   {

--- a/examples/T2-hypothesis-testing.ipynb
+++ b/examples/T2-hypothesis-testing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -76,16 +76,16 @@
       "\n",
       "Test Statistics  (ρ | z-score): 0.82522 | 5.44787\n",
       "P-value: 0.00185 **\n",
-      "Bootstrap P-value: 0.00690 **\n"
+      "Bootstrap P-value: 0.00770 **\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "RayleighTestResult(r=np.float64(0.8252177448200448), z=np.float64(5.4478746109270455), pval=np.float64(0.0018516375077209267), bootstrap_pval=np.float64(0.0069))"
+       "RayleighTestResult(r=np.float64(0.8252177448200448), z=np.float64(5.4478746109270455), pval=np.float64(0.0018516375077209267), bootstrap_pval=np.float64(0.0077))"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -247,7 +247,7 @@
        "ChiSquareTestResult(chi2=np.float64(66.54285714285714), pval=np.float64(5.518107289173823e-10))"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -272,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -390,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -479,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -519,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -555,7 +555,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -629,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -681,24 +681,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Last updated: 2025-01-31 14:47:26CET\n",
-      "\n",
-      "Python implementation: CPython\n",
-      "Python version       : 3.12.8\n",
-      "IPython version      : 8.31.0\n",
-      "\n",
-      "pycircstat2: 0.1.8\n",
-      "numpy      : 2.2.2\n",
-      "\n",
-      "Watermark: 2.5.0\n",
-      "\n"
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'watermark'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[42], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mget_ipython\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_line_magic\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mload_ext\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mwatermark\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m get_ipython()\u001b[38;5;241m.\u001b[39mrun_line_magic(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mwatermark\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m--time --date --timezone --updated --python --iversions --watermark\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
+      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:2482\u001b[0m, in \u001b[0;36mInteractiveShell.run_line_magic\u001b[0;34m(self, magic_name, line, _stack_depth)\u001b[0m\n\u001b[1;32m   2480\u001b[0m     kwargs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mlocal_ns\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_local_scope(stack_depth)\n\u001b[1;32m   2481\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbuiltin_trap:\n\u001b[0;32m-> 2482\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mfn\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   2484\u001b[0m \u001b[38;5;66;03m# The code below prevents the output from being displayed\u001b[39;00m\n\u001b[1;32m   2485\u001b[0m \u001b[38;5;66;03m# when using magics with decorator @output_can_be_silenced\u001b[39;00m\n\u001b[1;32m   2486\u001b[0m \u001b[38;5;66;03m# when the last Python token in the expression is a ';'.\u001b[39;00m\n\u001b[1;32m   2487\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mgetattr\u001b[39m(fn, magic\u001b[38;5;241m.\u001b[39mMAGIC_OUTPUT_CAN_BE_SILENCED, \u001b[38;5;28;01mFalse\u001b[39;00m):\n",
+      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/magics/extension.py:33\u001b[0m, in \u001b[0;36mExtensionMagics.load_ext\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m module_str:\n\u001b[1;32m     32\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m UsageError(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mMissing module name.\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m---> 33\u001b[0m res \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshell\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mextension_manager\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mload_extension\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m res \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124malready loaded\u001b[39m\u001b[38;5;124m'\u001b[39m:\n\u001b[1;32m     36\u001b[0m     \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m extension is already loaded. To reload it, use:\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m module_str)\n",
+      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/extensions.py:62\u001b[0m, in \u001b[0;36mExtensionManager.load_extension\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     55\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Load an IPython extension by its module name.\u001b[39;00m\n\u001b[1;32m     56\u001b[0m \n\u001b[1;32m     57\u001b[0m \u001b[38;5;124;03mReturns the string \"already loaded\" if the extension is already loaded,\u001b[39;00m\n\u001b[1;32m     58\u001b[0m \u001b[38;5;124;03m\"no load function\" if the module doesn't have a load_ipython_extension\u001b[39;00m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;124;03mfunction, or None if it succeeded.\u001b[39;00m\n\u001b[1;32m     60\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     61\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 62\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_load_extension\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     63\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mModuleNotFoundError\u001b[39;00m:\n\u001b[1;32m     64\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m module_str \u001b[38;5;129;01min\u001b[39;00m BUILTINS_EXTS:\n",
+      "File \u001b[0;32m~/src/pycircstat2/.venv/lib/python3.12/site-packages/IPython/core/extensions.py:77\u001b[0m, in \u001b[0;36mExtensionManager._load_extension\u001b[0;34m(self, module_str)\u001b[0m\n\u001b[1;32m     75\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshell\u001b[38;5;241m.\u001b[39mbuiltin_trap:\n\u001b[1;32m     76\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m module_str \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m sys\u001b[38;5;241m.\u001b[39mmodules:\n\u001b[0;32m---> 77\u001b[0m         mod \u001b[38;5;241m=\u001b[39m \u001b[43mimport_module\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodule_str\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     78\u001b[0m     mod \u001b[38;5;241m=\u001b[39m sys\u001b[38;5;241m.\u001b[39mmodules[module_str]\n\u001b[1;32m     79\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_call_load_ipython_extension(mod):\n",
+      "File \u001b[0;32m~/.local/share/uv/python/cpython-3.12.7-linux-x86_64-gnu/lib/python3.12/importlib/__init__.py:90\u001b[0m, in \u001b[0;36mimport_module\u001b[0;34m(name, package)\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[38;5;28;01mbreak\u001b[39;00m\n\u001b[1;32m     89\u001b[0m         level \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[0;32m---> 90\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_bootstrap\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_gcd_import\u001b[49m\u001b[43m(\u001b[49m\u001b[43mname\u001b[49m\u001b[43m[\u001b[49m\u001b[43mlevel\u001b[49m\u001b[43m:\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpackage\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlevel\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1387\u001b[0m, in \u001b[0;36m_gcd_import\u001b[0;34m(name, package, level)\u001b[0m\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1360\u001b[0m, in \u001b[0;36m_find_and_load\u001b[0;34m(name, import_)\u001b[0m\n",
+      "File \u001b[0;32m<frozen importlib._bootstrap>:1324\u001b[0m, in \u001b[0;36m_find_and_load_unlocked\u001b[0;34m(name, import_)\u001b[0m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'watermark'"
      ]
     }
    ],
@@ -706,6 +708,49 @@
     "%load_ext watermark\n",
     "%watermark --time --date --timezone --updated --python --iversions --watermark"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Angular Randomization Test (ART) for homogeneity of two groups "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Angular Randomization Test (ART) for Homogeneity\n",
+      "-------------------------------------------------\n",
+      "H0: The two samples come from the same population.\n",
+      "HA: The two samples do not come from the same population.\n",
+      "\n",
+      "Observed Test Statistic: 105.98051\n",
+      "P-value: 0.59141 \n"
+     ]
+    }
+   ],
+   "source": [
+    "from pycircstat2.hypothesis import angular_randomisation_test\n",
+    "\n",
+    "d = load_data(\"D13\", source=\"zar\")\n",
+    "c0 = Circular(data=d[d[\"sample\"] == 1][\"θ\"].values)\n",
+    "c1 = Circular(data=d[d[\"sample\"] == 2][\"θ\"].values)\n",
+    "\n",
+    "T, pval = angular_randomisation_test(circs=[c0, c1], n_simulation=1000, verbose=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -724,7 +769,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.7"
   },
   "orig_nbformat": 4
  },

--- a/pycircstat2/hypothesis.py
+++ b/pycircstat2/hypothesis.py
@@ -1011,8 +1011,7 @@ def angular_randomisation_test(
 
         # Compute absolute angular differences following the formula:
         # D(φᵢ,ψⱼ) = π - |π - |φᵢ - ψⱼ||
-        diff = np.abs(phi_reshaped - psi_reshaped)
-        distances = np.pi - np.abs(np.pi - diff)
+        distances = np.pi - np.abs(np.pi - np.abs(phi_reshaped - psi_reshaped))
 
         # Return sum of all distances
         return np.sum(distances)

--- a/pycircstat2/hypothesis.py
+++ b/pycircstat2/hypothesis.py
@@ -16,6 +16,7 @@ from .descriptive import (
     circ_median,
     circ_r,
     circ_range,
+    circ_pairdist,
 )
 from .utils import A1inv, angmod, angular_distance, significance_code
 
@@ -994,28 +995,6 @@ def angular_randomisation_test(
     International Journal of Nonlinear Analysis and Applications, 13(1), 2703-2711.
     """
 
-    def compute_geodesic_distance(phi: np.ndarray, psi: np.ndarray) -> np.ndarray:
-        """
-        Compute the sum of all pairwise geodesic distances between two sets of angles.
-
-        Args:
-            phi (np.ndarray): First set of angles in radians
-            psi (np.ndarray): Second set of angles in radians
-
-        Returns:
-            float: Sum of all pairwise geodesic distances
-        """
-        # Reshape arrays for broadcasting
-        phi_reshaped = phi.reshape(-1, 1)  # n x 1
-        psi_reshaped = psi.reshape(1, -1)  # 1 x m
-
-        # Compute absolute angular differences following the formula:
-        # D(φᵢ,ψⱼ) = π - |π - |φᵢ - ψⱼ||
-        distances = np.pi - np.abs(np.pi - np.abs(phi_reshaped - psi_reshaped))
-
-        # Return sum of all distances
-        return np.sum(distances)
-
     def art_statistic(S1: np.ndarray, S2: np.ndarray) -> float:
         """
         Compute the Angular Randomisation Test (ART) statistic for two groups of circular data.
@@ -1035,7 +1014,7 @@ def angular_randomisation_test(
         scaling_factor = np.sqrt(n * m / (n + m))
 
         # Compute sum of all pairwise geodesic distances
-        total_distance = compute_geodesic_distance(S1, S2)
+        total_distance = circ_pairdist(S1, S2, metric="geodesic", return_sum=True)
 
         # Scale the total distance and return
         return scaling_factor * total_distance

--- a/pycircstat2/hypothesis.py
+++ b/pycircstat2/hypothesis.py
@@ -96,9 +96,9 @@ def rayleigh_test(
     """
 
     if r is None:
-        assert isinstance(
-            alpha, np.ndarray
-        ), "If `r` is None, then `alpha` (and `w`) is needed."
+        assert isinstance(alpha, np.ndarray), (
+            "If `r` is None, then `alpha` (and `w`) is needed."
+        )
         if w is None:
             w = np.ones_like(alpha)
         n = np.sum(w, dtype=int)
@@ -113,7 +113,6 @@ def rayleigh_test(
     pval = np.exp(np.sqrt(1 + 4 * n + 4 * (n**2 - R**2)) - (1 + 2 * n))  # eq(27.4)
 
     if B > 1:
-
         tb = np.zeros(B)
         for i in range(B):
             x = np.random.normal(size=(n, 1))
@@ -254,9 +253,9 @@ def V_test(
     """
 
     if mean is None or r is None or n is None:
-        assert isinstance(
-            alpha, np.ndarray
-        ), "If `mean`, `r` or `n` is None, then `alpha` (and `w`) is needed."
+        assert isinstance(alpha, np.ndarray), (
+            "If `mean`, `r` or `n` is None, then `alpha` (and `w`) is needed."
+        )
         if w is None:
             w = np.ones_like(alpha)
         n = np.sum(w)
@@ -326,9 +325,9 @@ def one_sample_test(
     """
 
     if lb is None or ub is None:
-        assert isinstance(
-            alpha, np.ndarray
-        ), "If `ub` or `lb` is None, then `alpha` (and `w`) is needed."
+        assert isinstance(alpha, np.ndarray), (
+            "If `ub` or `lb` is None, then `alpha` (and `w`) is needed."
+        )
         if w is None:
             w = np.ones_like(alpha)
         lb, ub = circ_mean_ci(alpha=alpha, w=w)
@@ -776,9 +775,9 @@ def wallraff_test(
     P637-638, Section 27.8, Example 27.13 of Zar, 2010
     """
 
-    assert (
-        len(circs) == 2
-    ), "Current implementation only supports two-sample comparision."
+    assert len(circs) == 2, (
+        "Current implementation only supports two-sample comparision."
+    )
 
     angles = np.ones(len(circs)) * angle if isinstance(angle, float) else angle
     ns = [c.n for c in circs]
@@ -808,11 +807,11 @@ def wallraff_test(
 
 
 def circ_anova(
-    samples: list[np.ndarray], 
-    method: str = "F-test", 
-    kappa: Optional[float] = None, 
-    f_mod: bool = True, 
-    verbose: bool = False
+    samples: list[np.ndarray],
+    method: str = "F-test",
+    kappa: Optional[float] = None,
+    f_mod: bool = True,
+    verbose: bool = False,
 ) -> dict:
     """
     Circular Analysis of Variance (ANOVA) for multi-sample comparison of mean directions.
@@ -866,7 +865,9 @@ def circ_anova(
 
     # Sample sizes, mean directions, and resultants
     ns = np.array([len(group) for group in samples])
-    Rs = np.array([circ_r(group) * len(group) for group in samples])  # Sum of resultant vectors
+    Rs = np.array(
+        [circ_r(group) * len(group) for group in samples]
+    )  # Sum of resultant vectors
     mus = np.array([circ_mean(group) for group in samples])  # Mean directions
 
     # Overall resultant and mean direction
@@ -913,7 +914,7 @@ def circ_anova(
             "statistic": F_stat,
             "p_value": p_value,
             "SS": (SS_between, SS_within, SS_total),
-            "MS": (MS_between, MS_within)
+            "MS": (MS_between, MS_within),
         }
 
     # **Likelihood Ratio Test (LRT)**
@@ -960,6 +961,131 @@ def circ_anova(
         print("--------------------------------------\n")
 
     return result
+
+
+def angular_randomisation_test(
+    circs: list,
+    n_simulation: int = 1000,
+    verbose: bool = False,
+) -> tuple[float, float]:
+    """The Angular Randomization Test (ART) for homogeneity.
+
+    - H0: The two samples come from the same population.
+    - H1: The two samples do not come from the same population.
+
+    Parameters
+    ----------
+    circs: list
+        A list of Circular objects.
+    n_simulation: int, optional
+        Number of permutations for the test. Defaults to 1000.
+
+    Returns
+    -------
+    T_obs: float
+        Observed value of the ART test statistic.
+    p_value: float
+        p-value of the test.
+
+    Reference
+    ---------
+    Jebur, A. J., & Abushilah, S. F. (2022).
+    Distribution-free two-sample homogeneity test for circular data based on geodesic distance.
+    International Journal of Nonlinear Analysis and Applications, 13(1), 2703-2711.
+    """
+
+    def compute_geodesic_distance(phi: np.ndarray, psi: np.ndarray) -> np.ndarray:
+        """
+        Compute the sum of all pairwise geodesic distances between two sets of angles.
+
+        Args:
+            phi (np.ndarray): First set of angles in radians
+            psi (np.ndarray): Second set of angles in radians
+
+        Returns:
+            float: Sum of all pairwise geodesic distances
+        """
+        # Reshape arrays for broadcasting
+        phi_reshaped = phi.reshape(-1, 1)  # n x 1
+        psi_reshaped = psi.reshape(1, -1)  # 1 x m
+
+        # Compute absolute angular differences following the formula:
+        # D(φᵢ,ψⱼ) = π - |π - |φᵢ - ψⱼ||
+        diff = np.abs(phi_reshaped - psi_reshaped)
+        distances = np.pi - np.abs(np.pi - diff)
+
+        # Return sum of all distances
+        return np.sum(distances)
+
+    def art_statistic(S1: np.ndarray, S2: np.ndarray) -> float:
+        """
+        Compute the Angular Randomisation Test (ART) statistic for two groups of circular data.
+        Following equations (3.1) and (4.2) from Jebur & Abushilah (2022) .
+
+        Args:
+            S1 (np.ndarray): First group of angles in radians (φ values)
+            S2 (np.ndarray): Second group of angles in radians (ψ values)
+
+        Returns:
+            float: The ART test statistic
+        """
+        n = len(S1)
+        m = len(S2)
+
+        # Compute the scaling factor ((n+m)/(nm))^(-1/2)
+        scaling_factor = np.sqrt(n * m / (n + m))
+
+        # Compute sum of all pairwise geodesic distances
+        total_distance = compute_geodesic_distance(S1, S2)
+
+        # Scale the total distance and return
+        return scaling_factor * total_distance
+
+    # number of samples
+    k = len(circs)
+    if k != 2:
+        raise ValueError("The Angular Randomization Test requires exactly two samples.")
+
+    # 1. Compute observed test statistic T*₀
+    observed_stat = art_statistic(circs[0].alpha, circs[1].alpha)
+
+    # Initialize counter for permutations more extreme than observed
+    n_extreme = 1  # Start at 1 to count the observed statistic
+
+    # Combine samples for permutation
+    combined_data = np.concatenate([circs[0].alpha, circs[1].alpha])
+    n1 = len(circs[0].alpha)
+
+    # Perform permutation test
+
+    for _ in range(n_simulation):
+        # Randomly permute the combined data
+        permuted_data = np.random.permutation(combined_data)
+
+        # Split into two groups of original sizes
+        perm_S1 = permuted_data[:n1]
+        perm_S2 = permuted_data[n1:]
+
+        # Compute test statistic for this permutation
+        perm_stat = art_statistic(perm_S1, perm_S2)
+
+        # Count if permuted statistic is >= observed (one-sided test)
+        if perm_stat >= observed_stat:
+            n_extreme += 1
+
+    # Compute p-value as in equation (4.3)
+    p_value = n_extreme / (n_simulation + 1)
+
+    if verbose:
+        print("Angular Randomization Test (ART) for Homogeneity")
+        print("-------------------------------------------------")
+        print("H0: The two samples come from the same population.")
+        print("HA: The two samples do not come from the same population.")
+        print("")
+        print(f"Observed Test Statistic: {observed_stat:.5f}")
+        print(f"P-value: {p_value:.5f} {significance_code(p_value)}")
+
+    return observed_stat, p_value
 
 
 #####################
@@ -1229,6 +1355,7 @@ def rao_spacing_test(
 
     return np.rad2deg(Uo), pval
 
+
 def circ_range_test(alpha: np.ndarray) -> tuple[float, float]:
     """
     Perform the Circular Range Test for uniformity.
@@ -1260,8 +1387,11 @@ def circ_range_test(alpha: np.ndarray) -> tuple[float, float]:
     index = np.arange(1, stop + 1)
 
     # Compute p-value using series expansion
-    sequence = ((-1) ** (index - 1)) * comb(n, index) * \
-               (1 - index * (1 - range_stat / (2 * np.pi))) ** (n - 1)
+    sequence = (
+        ((-1) ** (index - 1))
+        * comb(n, index)
+        * (1 - index * (1 - range_stat / (2 * np.pi))) ** (n - 1)
+    )
     p_value = np.sum(sequence)
 
     return range_stat, p_value
@@ -1354,7 +1484,7 @@ def concentration_test(alpha1: np.ndarray, alpha2: np.ndarray) -> tuple[float, f
     """
     # Ensure inputs are numpy arrays
     alpha1, alpha2 = np.asarray(alpha1), np.asarray(alpha2)
-    
+
     # Sample sizes
     n1, n2 = len(alpha1), len(alpha2)
 
@@ -1371,7 +1501,7 @@ def concentration_test(alpha1: np.ndarray, alpha2: np.ndarray) -> tuple[float, f
 
     # Compute F-statistic
     f_stat = ((n2 - 1) * (n1 - R1)) / ((n1 - 1) * (n2 - R2))
-    
+
     # Compute p-value (adjusting for F-stat symmetry)
     if f_stat > 1:
         pval = 2 * (1 - f.cdf(f_stat, n1, n2))
@@ -1406,7 +1536,9 @@ def rao_homogeneity_test(samples: list, alpha: float = 0.05) -> dict:
     Jammalamadaka, S. Rao and SenGupta, A. (2001). Topics in Circular Statistics, Section 7.6.1.
     Rao, J.S. (1967). Large sample tests for the homogeneity of angular data, Sankhya, Ser, B., 28.
     """
-    if not isinstance(samples, list) or not all(isinstance(s, np.ndarray) for s in samples):
+    if not isinstance(samples, list) or not all(
+        isinstance(s, np.ndarray) for s in samples
+    ):
         raise ValueError("Input must be a list of numpy arrays.")
 
     k = len(samples)  # Number of samples
@@ -1422,16 +1554,36 @@ def rao_homogeneity_test(samples: list, alpha: float = 0.05) -> dict:
     var_sin = np.array([np.var(np.sin(s), ddof=1) for s in samples])
 
     # Compute covariance (use ddof=1 to match R's var(x, y))
-    cov_cos_sin = np.array([np.cov(np.cos(s), np.sin(s), ddof=1)[0, 1] for s in samples])
+    cov_cos_sin = np.array(
+        [np.cov(np.cos(s), np.sin(s), ddof=1)[0, 1] for s in samples]
+    )
 
     # Compute test statistics
-    s_polar = 1 / n * (var_sin / cos_means**2 + (sin_means**2 * var_cos) / cos_means**4 - (2 * sin_means * cov_cos_sin) / cos_means**3)
+    s_polar = (
+        1
+        / n
+        * (
+            var_sin / cos_means**2
+            + (sin_means**2 * var_cos) / cos_means**4
+            - (2 * sin_means * cov_cos_sin) / cos_means**3
+        )
+    )
     tan_means = sin_means / cos_means
-    H_polar = np.sum(tan_means**2 / s_polar) - (np.sum(tan_means / s_polar)**2) / np.sum(1 / s_polar)
+    H_polar = np.sum(tan_means**2 / s_polar) - (
+        np.sum(tan_means / s_polar) ** 2
+    ) / np.sum(1 / s_polar)
 
     U = cos_means**2 + sin_means**2
-    s_disp = 4 / n * (cos_means**2 * var_cos + sin_means**2 * var_sin + 2 * cos_means * sin_means * cov_cos_sin)
-    H_disp = np.sum(U**2 / s_disp) - (np.sum(U / s_disp)**2) / np.sum(1 / s_disp)
+    s_disp = (
+        4
+        / n
+        * (
+            cos_means**2 * var_cos
+            + sin_means**2 * var_sin
+            + 2 * cos_means * sin_means * cov_cos_sin
+        )
+    )
+    H_disp = np.sum(U**2 / s_disp) - (np.sum(U / s_disp) ** 2) / np.sum(1 / s_disp)
 
     # Compute p-values
     df = k - 1  # Degrees of freedom
@@ -1485,12 +1637,18 @@ def change_point_test(alpha):
         if i0(arg) != np.inf:
             return x * A1inv(x) - np.log(i0(arg))
         else:
-            return x * A1inv(x) - (arg + np.log(1 / np.sqrt(2 * np.pi * arg) * (1 + 1/(8 * arg) + 9/(128 * arg**2) + 225/(1024 * arg**3))))
+            return x * A1inv(x) - (
+                arg
+                + np.log(
+                    1
+                    / np.sqrt(2 * np.pi * arg)
+                    * (1 + 1 / (8 * arg) + 9 / (128 * arg**2) + 225 / (1024 * arg**3))
+                )
+            )
 
     def est_rho(alpha):
         """Estimate mean resultant length (rho)."""
         return np.linalg.norm(np.sum(np.exp(1j * alpha))) / len(alpha)
-
 
     n = len(alpha)
     if n < 4:
@@ -1499,15 +1657,17 @@ def change_point_test(alpha):
     rho = est_rho(alpha)
 
     R1, R2, V = np.zeros(n), np.zeros(n), np.zeros(n)
-    
-    for k in range(1, n):  
-        R1[k-1] = est_rho(alpha[:k]) * k  
-        R2[k-1] = est_rho(alpha[k:]) * (n - k)
 
-        if 2 <= k <= (n - 2): 
-            V[k-1] = (k/n) * phi(R1[k-1] / k) + ((n - k) / n) * phi(R2[k-1] / (n - k))
+    for k in range(1, n):
+        R1[k - 1] = est_rho(alpha[:k]) * k
+        R2[k - 1] = est_rho(alpha[k:]) * (n - k)
 
-    R1[-1] = rho * n 
+        if 2 <= k <= (n - 2):
+            V[k - 1] = (k / n) * phi(R1[k - 1] / k) + ((n - k) / n) * phi(
+                R2[k - 1] / (n - k)
+            )
+
+    R1[-1] = rho * n
     R2[-1] = 0
 
     R_diff = R1 + R2 - rho * n
@@ -1516,50 +1676,57 @@ def change_point_test(alpha):
     rave = np.mean(R_diff)
 
     if n > 3:
-        V = V[1:n-2]
+        V = V[1 : n - 2]
         print(f"V sliced: {V}")
         tmax = np.max(V)
         k_t = np.argmax(V) + 1
-        tave = np.mean(V) 
+        tave = np.mean(V)
     else:
         raise ValueError("Sample size must be at least 4.")
 
-    return pd.DataFrame({
-        "n": [n],
-        "rho": [rho],
-        "rmax": [rmax],
-        "k.r": [k_r],
-        "rave": [rave],
-        "tmax": [tmax],
-        "k.t": [k_t],
-        "tave": [tave],
-    })
+    return pd.DataFrame(
+        {
+            "n": [n],
+            "rho": [rho],
+            "rmax": [rmax],
+            "k.r": [k_r],
+            "rave": [rave],
+            "tmax": [tmax],
+            "k.t": [k_t],
+            "tave": [tave],
+        }
+    )
 
 
-def harrison_kanji_test(alpha: np.ndarray, idp: np.ndarray, idq: np.ndarray, inter: bool = True, fn: Optional[list] = None) -> tuple[tuple[float, float, float], pd.DataFrame]:
+def harrison_kanji_test(
+    alpha: np.ndarray,
+    idp: np.ndarray,
+    idq: np.ndarray,
+    inter: bool = True,
+    fn: Optional[list] = None,
+) -> tuple[tuple[float, float, float], pd.DataFrame]:
     """
     Harrison-Kanji Test (Two-Way ANOVA) for Circular Data.
     """
 
     if fn is None:
-        fn = ['A', 'B']
+        fn = ["A", "B"]
 
     # Ensure data is in column format
     alpha = np.asarray(alpha).flatten()
     idp = np.asarray(idp).flatten()
     idq = np.asarray(idq).flatten()
 
-
     # Number of factor levels
     p = len(np.unique(idp))
     q = len(np.unique(idq))
 
     # Data frame for aggregation
-    df = pd.DataFrame({fn[0]: idp, fn[1]: idq, 'dependent': alpha})
+    df = pd.DataFrame({fn[0]: idp, fn[1]: idq, "dependent": alpha})
     n = len(df)
 
     # Total resultant vector length
-    tr = n * circ_r(df['dependent'])
+    tr = n * circ_r(df["dependent"])
     kk = circ_kappa(tr / n)
 
     # Compute mean resultants per group
@@ -1571,44 +1738,49 @@ def harrison_kanji_test(alpha: np.ndarray, idp: np.ndarray, idq: np.ndarray, int
 
     # Factor A
     gr = df.groupby(fn[0])
-    pn = gr.count()['dependent']
-    pr = gr.agg(circ_r)['dependent'] * pn
-    pm = gr.agg(circ_mean)['dependent']
+    pn = gr.count()["dependent"]
+    pr = gr.agg(circ_r)["dependent"] * pn
+    pm = gr.agg(circ_mean)["dependent"]
 
     # Factor B
     gr = df.groupby(fn[1])
-    qn = gr.count()['dependent']
-    qr = gr.agg(circ_r)['dependent'] * qn
-    qm = gr.agg(circ_mean)['dependent']
+    qn = gr.count()["dependent"]
+    qr = gr.agg(circ_r)["dependent"] * qn
+    qm = gr.agg(circ_mean)["dependent"]
 
     if kk > 2:  # Large kappa approximation
-        eff_1 = sum(pr ** 2 / cn.sum(axis=1)) - tr ** 2 / n
+        eff_1 = sum(pr**2 / cn.sum(axis=1)) - tr**2 / n
         df_1 = p - 1
         ms_1 = eff_1 / df_1
 
-        eff_2 = sum(qr ** 2 / cn.sum(axis=0)) - tr ** 2 / n
+        eff_2 = sum(qr**2 / cn.sum(axis=0)) - tr**2 / n
         df_2 = q - 1
         ms_2 = eff_2 / df_2
 
-        eff_t = n - tr ** 2 / n
+        eff_t = n - tr**2 / n
         df_t = n - 1
         m = cn.values.mean()
 
         if inter:
-            beta = 1 / (1 - 1 / (5 * kk) - 1 / (10 * (kk ** 2)))
+            beta = 1 / (1 - 1 / (5 * kk) - 1 / (10 * (kk**2)))
 
-            eff_r = n - (cr**2./cn).values.sum()
+            eff_r = n - (cr**2.0 / cn).values.sum()
             df_r = p * q * (m - 1)
             ms_r = eff_r / df_r
 
-            eff_i = (cr**2./cn).values.sum() - sum(qr**2./qn) - sum(pr**2./pn) + tr**2 / n
+            eff_i = (
+                (cr**2.0 / cn).values.sum()
+                - sum(qr**2.0 / qn)
+                - sum(pr**2.0 / pn)
+                + tr**2 / n
+            )
             df_i = (p - 1) * (q - 1)
             ms_i = eff_i / df_i
 
             FI = ms_i / ms_r
             pI = 1 - f.cdf(FI, df_i, df_r)  # `f.cdf` is now unambiguous
         else:
-            eff_r = n - sum(qr**2./qn) - sum(pr**2./pn) + tr**2 / n
+            eff_r = n - sum(qr**2.0 / qn) - sum(pr**2.0 / pn) + tr**2 / n
             df_r = (p - 1) * (q - 1)
             ms_r = eff_r / df_r
 
@@ -1623,17 +1795,22 @@ def harrison_kanji_test(alpha: np.ndarray, idp: np.ndarray, idq: np.ndarray, int
 
     else:  # Small kappa approximation
         rr = iv(1, kk) / iv(0, kk)
-        kappa_factor = 2 / (1 - rr ** 2)  # Renamed `f` to `kappa_factor`
+        kappa_factor = 2 / (1 - rr**2)  # Renamed `f` to `kappa_factor`
 
-        chi1 = kappa_factor * (sum(pr**2./pn) - tr**2 / n)
+        chi1 = kappa_factor * (sum(pr**2.0 / pn) - tr**2 / n)
         df_1 = 2 * (p - 1)
         p1 = 1 - chi2.cdf(chi1, df=df_1)
 
-        chi2_val = kappa_factor * (sum(qr**2./qn) - tr**2 / n)
+        chi2_val = kappa_factor * (sum(qr**2.0 / qn) - tr**2 / n)
         df_2 = 2 * (q - 1)
         p2 = 1 - chi2.cdf(chi2_val, df=df_2)
 
-        chiI = kappa_factor * ((cr**2./cn).values.sum() - sum(pr**2./pn) - sum(qr**2./qn) + tr**2 / n)
+        chiI = kappa_factor * (
+            (cr**2.0 / cn).values.sum()
+            - sum(pr**2.0 / pn)
+            - sum(qr**2.0 / qn)
+            + tr**2 / n
+        )
         df_i = (p - 1) * (q - 1)
         pI = chi2.sf(chiI, df=df_i)
 
@@ -1641,21 +1818,25 @@ def harrison_kanji_test(alpha: np.ndarray, idp: np.ndarray, idq: np.ndarray, int
 
     # Construct ANOVA Table
     if kk > 2:
-        table = pd.DataFrame({
-            'Source': fn + ['Interaction', 'Residual', 'Total'],
-            'DoF': [df_1, df_2, df_i, df_r, df_t],
-            'SS': [eff_1, eff_2, eff_i, eff_r, eff_t],
-            'MS': [ms_1, ms_2, ms_i, ms_r, np.nan],
-            'F': [F1.squeeze(), F2.squeeze(), FI, np.nan, np.nan],
-            'p': list(pval) + [np.nan, np.nan]
-        }).set_index('Source')
+        table = pd.DataFrame(
+            {
+                "Source": fn + ["Interaction", "Residual", "Total"],
+                "DoF": [df_1, df_2, df_i, df_r, df_t],
+                "SS": [eff_1, eff_2, eff_i, eff_r, eff_t],
+                "MS": [ms_1, ms_2, ms_i, ms_r, np.nan],
+                "F": [F1.squeeze(), F2.squeeze(), FI, np.nan, np.nan],
+                "p": list(pval) + [np.nan, np.nan],
+            }
+        ).set_index("Source")
     else:
-        table = pd.DataFrame({
-            'Source': fn + ['Interaction'],
-            'DoF': [df_1, df_2, df_i],
-            'chi2': [chi1.squeeze(), chi2_val.squeeze(), chiI.squeeze()],
-            'p': pval
-        }).set_index('Source')
+        table = pd.DataFrame(
+            {
+                "Source": fn + ["Interaction"],
+                "DoF": [df_1, df_2, df_i],
+                "chi2": [chi1.squeeze(), chi2_val.squeeze(), chiI.squeeze()],
+                "p": pval,
+            }
+        ).set_index("Source")
 
     return pval, table
 
@@ -1692,7 +1873,7 @@ def equal_kappa_test(samples: list[np.ndarray], verbose: bool = False) -> dict:
       - **Small `r̄` (< 0.45)**: Uses `arcsin` transformation.
       - **Moderate `r̄` (0.45 - 0.7)**: Uses `asinh` transformation.
       - **Large `r̄` (> 0.7)**: Uses Bartlett-type test (log-likelihood method).
-    
+
     References
     ----------
     - Jammalamadaka & SenGupta (2001), Section 5.4.
@@ -1725,21 +1906,23 @@ def equal_kappa_test(samples: list[np.ndarray], verbose: bool = False) -> dict:
     if r_bar_all < 0.45:
         # Small `r̄`: arcsin transformation
         ws = 4 * (ns - 4) / 3
-        g1s = np.arcsin(np.sqrt(3/8) * 2 * r_bars)
-        chi_square_stat = np.sum(ws * g1s**2) - (np.sum(ws * g1s)**2 / np.sum(ws))
+        g1s = np.arcsin(np.sqrt(3 / 8) * 2 * r_bars)
+        chi_square_stat = np.sum(ws * g1s**2) - (np.sum(ws * g1s) ** 2 / np.sum(ws))
 
     elif 0.45 <= r_bar_all <= 0.7:
         # Moderate `r̄`: asinh transformation
         ws = (ns - 3) / 0.798
         g2s = np.arcsinh((r_bars - 1.089) / 0.258)
-        chi_square_stat = np.sum(ws * g2s**2) - (np.sum(ws * g2s)**2 / np.sum(ws))
+        chi_square_stat = np.sum(ws * g2s**2) - (np.sum(ws * g2s) ** 2 / np.sum(ws))
 
     else:
         # Large `r̄`: Bartlett-type test
         vs = ns - 1
         v = N - k
         d = 1 / (3 * (k - 1)) * (np.sum(1 / vs) - 1 / v)
-        chi_square_stat = (1 / (1 + d)) * (v * np.log((N - np.sum(Rs)) / v) - np.sum(vs * np.log((ns - Rs) / vs)))
+        chi_square_stat = (1 / (1 + d)) * (
+            v * np.log((N - np.sum(Rs)) / v) - np.sum(vs * np.log((ns - Rs) / vs))
+        )
 
     # Compute p-value
     df = k - 1
@@ -1752,7 +1935,7 @@ def equal_kappa_test(samples: list[np.ndarray], verbose: bool = False) -> dict:
         "rho_all": r_bar_all,
         "df": df,
         "statistic": chi_square_stat,
-        "p_value": p_value
+        "p_value": p_value,
     }
 
     # Print results if verbose is enabled
@@ -1769,6 +1952,7 @@ def equal_kappa_test(samples: list[np.ndarray], verbose: bool = False) -> dict:
         print("------------------------------------------------------\n")
 
     return result
+
 
 def common_median_test(samples: list[np.ndarray], verbose: bool = False) -> dict:
     """
@@ -1834,7 +2018,7 @@ def common_median_test(samples: list[np.ndarray], verbose: bool = False) -> dict
         "common_median": common_median,
         "test_statistic": P,
         "p_value": p_value,
-        "reject": reject
+        "reject": reject,
     }
 
     # Print results if verbose is enabled

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -225,7 +225,12 @@ def test_watson_test():
 
 
 def test_angular_randomisation_test():
-    pass
+    np.random.seed(42)
+    alpha1 = Circular(np.random.vonmises(mu=0, kappa=3, size=10), unit="radian")
+    alpha2 = Circular(np.random.vonmises(mu=0, kappa=3, size=50), unit="radian")
+
+    observed_stat, p_value = angular_randomisation_test([alpha1, alpha2])
+    assert p_value > 0.05, "Expected non-significant p-value"
 
 
 def test_rao_spacing_test():

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -26,11 +26,11 @@ from pycircstat2.hypothesis import (
     watson_u2_test,
     watson_williams_test,
     wheeler_watson_test,
+    angular_randomisation_test,
 )
 
 
 def test_rayleigh_test():
-
     # Ch27 Example 1 (Zar, 2010, P667)
     # Using data from Ch26 Example 2.
     data_zar_ex2_ch26 = load_data("D1", source="zar")
@@ -48,7 +48,6 @@ def test_rayleigh_test():
 
 
 def test_V_test():
-
     # Ch27 Example 2 (Zar, 2010, P669)
     data_zar_ex2_ch27 = load_data("D7", source="zar")
     circ_zar_ex2_ch27 = Circular(data=data_zar_ex2_ch27["θ"].values)
@@ -77,7 +76,6 @@ def test_V_test():
 
 
 def test_one_sample_test():
-
     # Ch27 Example 3 (Zar, 2010, P669)
     # Using data from Ch27 Example 2
     data_zar_ex2_ch27 = load_data("D7", source="zar")
@@ -99,7 +97,6 @@ def test_one_sample_test():
 
 
 def test_omnibus_test():
-
     data_zar_ex4_ch27 = load_data("D8", source="zar")
     circ_zar_ex4_ch27 = Circular(data=data_zar_ex4_ch27["θ"].values, unit="degree")
 
@@ -109,7 +106,6 @@ def test_omnibus_test():
 
 
 def test_batschelet_test():
-
     data_zar_ex5_ch27 = load_data("D8", source="zar")
     circ_zar_ex5_ch27 = Circular(data=data_zar_ex5_ch27["θ"].values, unit="degree")
 
@@ -122,7 +118,6 @@ def test_batschelet_test():
 
 
 def test_chisquare_test():
-
     d2 = load_data("D2", source="zar")
     c2 = Circular(data=d2["θ"].values, w=d2["w"].values)
 
@@ -132,7 +127,6 @@ def test_chisquare_test():
 
 
 def test_symmetry_test():
-
     data_zar_ex6_ch27 = load_data("D9", source="zar")
     circ_zar_ex6_ch27 = Circular(data=data_zar_ex6_ch27["θ"].values, unit="degree")
 
@@ -141,7 +135,6 @@ def test_symmetry_test():
 
 
 def test_watson_williams_test():
-
     data = load_data("D10", source="zar")
     s1 = Circular(data=data[data["sample"] == 1]["θ"].values)
     s2 = Circular(data=data[data["sample"] == 2]["θ"].values)
@@ -162,7 +155,6 @@ def test_watson_williams_test():
 
 
 def test_watson_u2_test():
-
     d = load_data("D12", source="zar")
     c0 = Circular(data=d[d["sample"] == 1]["θ"].values)
     c1 = Circular(data=d[d["sample"] == 2]["θ"].values)
@@ -195,7 +187,6 @@ def test_wheeler_watson_test():
 
 
 def test_wallraff_test():
-
     d = load_data("D14", source="zar")
     c0 = Circular(data=d[d["sex"] == "male"]["θ"].values)
     c1 = Circular(data=d[d["sex"] == "female"]["θ"].values)
@@ -218,7 +209,6 @@ def test_wallraff_test():
 
 
 def test_kuiper_test():
-
     d = load_data("B5", source="fisher")["θ"].values
     c = Circular(data=d, unit="degree", n_intervals=180)
     V, pval = kuiper_test(alpha=c.alpha)
@@ -227,12 +217,15 @@ def test_kuiper_test():
 
 
 def test_watson_test():
-
     pigeon = np.array([20, 135, 145, 165, 170, 200, 300, 325, 335, 350, 350, 350, 355])
     c_pigeon = Circular(data=pigeon)
     U2, pval = watson_test(alpha=c_pigeon.alpha, n_simulation=9999)
     np.testing.assert_approx_equal(U2, 0.137, significant=3)
     assert pval > 0.10
+
+
+def test_angular_randomisation_test():
+    pass
 
 
 def test_rao_spacing_test():
@@ -242,10 +235,36 @@ def test_rao_spacing_test():
     np.testing.assert_approx_equal(U, 161.92308, significant=3)
     assert 0.05 < pval < 0.10
 
+
 def test_circ_range_test():
-
-
-    x = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.6, 36.0, 36.0, 36.0, 36.0, 36.0, 36.0, 72.0, 108.0, 108.0, 169.2, 324.0])
+    x = np.array(
+        [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            3.6,
+            36.0,
+            36.0,
+            36.0,
+            36.0,
+            36.0,
+            36.0,
+            72.0,
+            108.0,
+            108.0,
+            169.2,
+            324.0,
+        ]
+    )
     range_stat, pval = circ_range_test(x)
     np.testing.assert_approx_equal(range_stat, 4.584073, significant=5)
     np.testing.assert_approx_equal(pval, 0.01701148, significant=5)
@@ -256,39 +275,43 @@ def test_binomial_test_uniform():
     np.random.seed(42)
     alpha = np.random.uniform(0, 2 * np.pi, 100)  # Uniformly distributed angles
     md = np.pi  # Test median at π (should be non-significant)
-    
+
     pval = binomial_test(alpha, md)
-    
+
     assert 0.05 < pval < 1.0, f"Unexpected p-value for uniform data: {pval}"
+
 
 def test_binomial_test_skewed():
     """Test binomial_test with a skewed circular distribution (should reject H0)."""
     np.random.seed(42)
-    alpha = np.random.vonmises(mu=np.pi/4, kappa=3, size=100)  # Clustered around π/4
+    alpha = np.random.vonmises(mu=np.pi / 4, kappa=3, size=100)  # Clustered around π/4
     md = np.pi  # Incorrect median hypothesis
-    
+
     pval = binomial_test(alpha, md)
-    
+
     assert pval < 0.05, f"Expected significant p-value but got {pval}"
+
 
 def test_binomial_test_symmetric():
     """Test binomial_test with symmetric distribution around π (should fail to reject H0)."""
-    alpha = np.array([-np.pi/4, np.pi/4, np.pi/2, -np.pi/2, np.pi])
+    alpha = np.array([-np.pi / 4, np.pi / 4, np.pi / 2, -np.pi / 2, np.pi])
     md = np.pi  # This should be a valid median
-    
+
     pval = binomial_test(alpha, md)
-    
+
     assert pval > 0.05, f"Unexpected p-value for symmetric data: {pval}"
+
 
 def test_binomial_test_extreme_case():
     """Test binomial_test with all points clustered at π (extreme case)."""
     alpha = np.full(20, np.pi)  # All angles at π
     md = np.pi
-    
-    pval = binomial_test(alpha, md)
-    
-    assert np.isclose(pval, 1.0), f"Expected p-value of 1 for identical data but got {pval}"
 
+    pval = binomial_test(alpha, md)
+
+    assert np.isclose(pval, 1.0), (
+        f"Expected p-value of 1 for identical data but got {pval}"
+    )
 
 
 def test_concentration_identical():
@@ -301,6 +324,7 @@ def test_concentration_identical():
 
     assert pval > 0.05, f"Unexpectedly small p-value: {pval}, should not reject H0."
 
+
 def test_concentration_different():
     """Test concentration_test with different kappa values (should reject H0)."""
     np.random.seed(42)
@@ -311,11 +335,12 @@ def test_concentration_different():
 
     assert pval < 0.05, f"Expected small p-value, but got {pval}"
 
+
 def test_concentration_high_dispersion():
     """Test concentration_test with very dispersed data (should fail to reject H0)."""
     np.random.seed(42)
-    alpha1 = np.random.uniform(0, 2*np.pi, 50)  # Uniformly spread
-    alpha2 = np.random.uniform(0, 2*np.pi, 50)
+    alpha1 = np.random.uniform(0, 2 * np.pi, 50)  # Uniformly spread
+    alpha2 = np.random.uniform(0, 2 * np.pi, 50)
 
     f_stat, pval = concentration_test(alpha1, alpha2)
 
@@ -333,7 +358,6 @@ def test_concentration_extreme_case():
     assert pval > 0.05, f"Unexpectedly small p-value: {pval}, should not reject H0."
 
 
-
 def test_rao_homogeneity_identical():
     """Test with identical von Mises distributions (should fail to reject H0)."""
     np.random.seed(42)
@@ -341,20 +365,28 @@ def test_rao_homogeneity_identical():
 
     results = rao_homogeneity_test(samples)
 
-    assert results["pval_polar"] > 0.05, f"Unexpectedly small p-value: {results['pval_polar']}"
-    assert results["pval_disp"] > 0.05, f"Unexpectedly small p-value: {results['pval_disp']}"
+    assert results["pval_polar"] > 0.05, (
+        f"Unexpectedly small p-value: {results['pval_polar']}"
+    )
+    assert results["pval_disp"] > 0.05, (
+        f"Unexpectedly small p-value: {results['pval_disp']}"
+    )
+
 
 def test_rao_homogeneity_different_means():
     """Test with different mean directions (should reject H0 for mean equality)."""
     np.random.seed(42)
     samples = [
         vonmises.rvs(kappa=2, mu=0, size=50),
-        vonmises.rvs(kappa=2, mu=np.pi/4, size=50),
-        vonmises.rvs(kappa=2, mu=np.pi/2, size=50)
+        vonmises.rvs(kappa=2, mu=np.pi / 4, size=50),
+        vonmises.rvs(kappa=2, mu=np.pi / 2, size=50),
     ]
     results = rao_homogeneity_test(samples)
 
-    assert results["pval_polar"] < 0.05, f"Expected rejection but got p={results['pval_polar']}"
+    assert results["pval_polar"] < 0.05, (
+        f"Expected rejection but got p={results['pval_polar']}"
+    )
+
 
 def test_rao_homogeneity_different_dispersion():
     """Test with different kappa values (should reject H0 for dispersion equality)."""
@@ -362,12 +394,15 @@ def test_rao_homogeneity_different_dispersion():
     samples = [
         vonmises.rvs(mu=0, kappa=5, size=50),
         vonmises.rvs(mu=0, kappa=2, size=50),
-        vonmises.rvs(mu=0, kappa=1, size=50)
+        vonmises.rvs(mu=0, kappa=1, size=50),
     ]
 
     results = rao_homogeneity_test(samples)
 
-    assert results["pval_disp"] < 0.05, f"Expected rejection but got p={results['pval_disp']}"
+    assert results["pval_disp"] < 0.05, (
+        f"Expected rejection but got p={results['pval_disp']}"
+    )
+
 
 def test_rao_homogeneity_small_samples():
     """Test with very small sample sizes (should handle without error)."""
@@ -378,19 +413,38 @@ def test_rao_homogeneity_small_samples():
 
     assert "pval_polar" in results and "pval_disp" in results
 
+
 def test_rao_homogeneity_invalid_input():
     """Test invalid input (should raise ValueError)."""
     with pytest.raises(ValueError):
         rao_homogeneity_test("invalid_input")
 
     with pytest.raises(ValueError):
-        rao_homogeneity_test([np.array([0, np.pi/2]), "invalid_array"])
+        rao_homogeneity_test([np.array([0, np.pi / 2]), "invalid_array"])
+
 
 def test_change_point_basic():
     """Test change_point_test() on a simple dataset matching R."""
-    alpha = np.array([3.03, 0.28, 3.90, 5.56, 5.77, 5.06, 5.96, 
-                      0.16, 0.51, 1.21, 6.03, 1.05, 0.45, 1.47, 6.09])
-    
+    alpha = np.array(
+        [
+            3.03,
+            0.28,
+            3.90,
+            5.56,
+            5.77,
+            5.06,
+            5.96,
+            0.16,
+            0.51,
+            1.21,
+            6.03,
+            1.05,
+            0.45,
+            1.47,
+            6.09,
+        ]
+    )
+
     result = change_point_test(alpha)
 
     # Expected values based on R output
@@ -410,6 +464,7 @@ def test_change_point_basic():
     assert result["k.t"].iloc[0] == expected_k_t
     assert np.isclose(result["tave"].iloc[0], expected_tave, atol=1e-5)
 
+
 def test_harrison_kanji_test():
     """Test Harrison-Kanji two-way ANOVA for circular data."""
     np.random.seed(42)
@@ -423,9 +478,13 @@ def test_harrison_kanji_test():
     assert anova_table.shape[0] >= 3  # At least 3 sources in ANOVA table
     assert all(0 <= p <= 1 for p in pval if p is not None)  # Valid p-values
 
-@pytest.mark.skip(reason="Skipped unless explicitly called with `-k test_harrison_kanji_vs_pycircstat`")
+
+@pytest.mark.skip(
+    reason="Skipped unless explicitly called with `-k test_harrison_kanji_vs_pycircstat`"
+)
 def test_harrison_kanji_vs_pycircstat():
     """Compare PyCircStat2 `harrison_kanji_test` with original PyCircStat `hktest`."""
+
     def hktest(alpha, idp, idq, inter=True, fn=None):
         """copied and fixed from pycircstat.hktest"""
         import pandas as pd
@@ -434,12 +493,12 @@ def test_harrison_kanji_vs_pycircstat():
         from pycircstat2.descriptive import circ_kappa, circ_mean, circ_r
 
         if fn is None:
-            fn = ['A', 'B']
+            fn = ["A", "B"]
         p = len(np.unique(idp))
         q = len(np.unique(idq))
-        df = pd.DataFrame({fn[0]: idp, fn[1]: idq, 'dependent': alpha})
+        df = pd.DataFrame({fn[0]: idp, fn[1]: idq, "dependent": alpha})
         n = len(df)
-        tr = n * circ_r(df['dependent'])
+        tr = n * circ_r(df["dependent"])
         kk = circ_kappa(tr / n)
 
         # both factors
@@ -451,51 +510,55 @@ def test_harrison_kanji_vs_pycircstat():
 
         # factor A
         gr = df.groupby(fn[0])
-        pn = gr.count()['dependent']
-        pr = gr.agg(circ_r)['dependent'] * pn
-        pm = gr.agg(circ_mean)['dependent']
+        pn = gr.count()["dependent"]
+        pr = gr.agg(circ_r)["dependent"] * pn
+        pm = gr.agg(circ_mean)["dependent"]
         # factor B
         gr = df.groupby(fn[1])
-        qn = gr.count()['dependent']
-        qr = gr.agg(circ_r)['dependent'] * qn
-        qm = gr.agg(circ_mean)['dependent']
+        qn = gr.count()["dependent"]
+        qr = gr.agg(circ_r)["dependent"] * qn
+        qm = gr.agg(circ_mean)["dependent"]
 
         if kk > 2:  # large kappa
             # effect of factor 1
-            eff_1 = sum(pr ** 2 / cn.sum(axis=1)) - tr ** 2 / n
+            eff_1 = sum(pr**2 / cn.sum(axis=1)) - tr**2 / n
             df_1 = p - 1
             ms_1 = eff_1 / df_1
 
             # effect of factor 2
-            eff_2 = sum(qr ** 2. / cn.sum(axis=0)) - tr ** 2 / n
+            eff_2 = sum(qr**2.0 / cn.sum(axis=0)) - tr**2 / n
             df_2 = q - 1
             ms_2 = eff_2 / df_2
 
             # total effect
-            eff_t = n - tr ** 2 / n
+            eff_t = n - tr**2 / n
             df_t = n - 1
             m = cn.values.mean()
 
             if inter:
                 # correction factor for improved F statistic
-                beta = 1 / (1 - 1 / (5 * kk) - 1 / (10 * (kk ** 2)))
+                beta = 1 / (1 - 1 / (5 * kk) - 1 / (10 * (kk**2)))
                 # residual effects
-                eff_r = n - (cr**2./cn).values.sum()
-                df_r = p*q*(m-1)
+                eff_r = n - (cr**2.0 / cn).values.sum()
+                df_r = p * q * (m - 1)
                 ms_r = eff_r / df_r
 
                 # interaction effects
-                eff_i = (cr**2./cn).values.sum() - sum(qr**2./qn) - sum(pr**2./pn) + tr**2/n
-                df_i = (p-1)*(q-1)
-                ms_i = eff_i/df_i;
-
+                eff_i = (
+                    (cr**2.0 / cn).values.sum()
+                    - sum(qr**2.0 / qn)
+                    - sum(pr**2.0 / pn)
+                    + tr**2 / n
+                )
+                df_i = (p - 1) * (q - 1)
+                ms_i = eff_i / df_i
                 # interaction test statistic
                 FI = ms_i / ms_r
-                pI = 1 - stats.f.cdf(FI,df_i,df_r)
+                pI = 1 - stats.f.cdf(FI, df_i, df_r)
             else:
                 # residual effect
-                eff_r = n - sum(qr**2./qn)- sum(pr**2./pn) + tr**2/n
-                df_r = (p-1)*(q-1)
+                eff_r = n - sum(qr**2.0 / qn) - sum(pr**2.0 / pn) + tr**2 / n
+                df_r = (p - 1) * (q - 1)
                 ms_r = eff_r / df_r
 
                 # interaction effects
@@ -508,53 +571,59 @@ def test_harrison_kanji_vs_pycircstat():
                 pI = np.nan
                 beta = 1
 
-
             F1 = beta * ms_1 / ms_r
-            p1 = 1 - stats.f.cdf(F1,df_1,df_r)
+            p1 = 1 - stats.f.cdf(F1, df_1, df_r)
 
             F2 = beta * ms_2 / ms_r
-            p2 = 1 - stats.f.cdf(F2,df_2,df_r)
+            p2 = 1 - stats.f.cdf(F2, df_2, df_r)
 
-        else: #small kappa
+        else:  # small kappa
             # correction factor
             # special.iv is Modified Bessel function of the first kind of real order
-            rr = special.iv(1,kk) / special.iv(0,kk)
-            f = 2/(1-rr**2)
+            rr = special.iv(1, kk) / special.iv(0, kk)
+            f = 2 / (1 - rr**2)
 
-            chi1 = f * (sum(pr**2./pn)- tr**2/n)
-            df_1 = 2*(p-1)
+            chi1 = f * (sum(pr**2.0 / pn) - tr**2 / n)
+            df_1 = 2 * (p - 1)
             p1 = 1 - stats.chi2.cdf(chi1, df=df_1)
 
-            chi2 = f * (sum(qr**2./qn)- tr**2/n)
-            df_2 = 2*(q-1)
+            chi2 = f * (sum(qr**2.0 / qn) - tr**2 / n)
+            df_2 = 2 * (q - 1)
             p2 = 1 - stats.chi2.cdf(chi2, df=df_2)
 
-            chiI = f * ( (cr**2./cn).values.sum() - sum(pr**2./pn) - sum(qr**2./qn) + tr**2/n)
-            df_i = (p-1) * (q-1)
+            chiI = f * (
+                (cr**2.0 / cn).values.sum()
+                - sum(pr**2.0 / pn)
+                - sum(qr**2.0 / qn)
+                + tr**2 / n
+            )
+            df_i = (p - 1) * (q - 1)
             pI = stats.chi2.sf(chiI, df=df_i)
-
-
 
         pval = (p1.squeeze(), p2.squeeze(), pI.squeeze())
 
-        if kk>2:
-            table = pd.DataFrame({
-                'Source': fn + ['Interaction', 'Residual', 'Total'],
-                'DoF': [df_1, df_2, df_i, df_r, df_t],
-                'SS': [eff_1, eff_2, eff_i, eff_r, eff_t],
-                'MS': [ms_1, ms_2, ms_i, ms_r, np.nan],
-                'F': [F1.squeeze(), F2.squeeze(), FI, np.nan, np.nan],
-                'p': list(pval) + [np.nan, np.nan]
-            })
-            table = table.set_index('Source')
+        if kk > 2:
+            table = pd.DataFrame(
+                {
+                    "Source": fn + ["Interaction", "Residual", "Total"],
+                    "DoF": [df_1, df_2, df_i, df_r, df_t],
+                    "SS": [eff_1, eff_2, eff_i, eff_r, eff_t],
+                    "MS": [ms_1, ms_2, ms_i, ms_r, np.nan],
+                    "F": [F1.squeeze(), F2.squeeze(), FI, np.nan, np.nan],
+                    "p": list(pval) + [np.nan, np.nan],
+                }
+            )
+            table = table.set_index("Source")
         else:
-            table = pd.DataFrame({
-                'Source': fn + ['Interaction'],
-                'DoF': [df_1, df_2, df_i],
-                'chi2': [chi1.squeeze(), chi2.squeeze(), chiI.squeeze()],
-                'p': pval
-            })
-            table = table.set_index('Source')
+            table = pd.DataFrame(
+                {
+                    "Source": fn + ["Interaction"],
+                    "DoF": [df_1, df_2, df_i],
+                    "chi2": [chi1.squeeze(), chi2.squeeze(), chiI.squeeze()],
+                    "p": pval,
+                }
+            )
+            table = table.set_index("Source")
 
         return pval, table
 
@@ -569,13 +638,18 @@ def test_harrison_kanji_vs_pycircstat():
     pval_new, table_new = harrison_kanji_test(alpha, idp, idq)
 
     # Compare p-values
-    assert np.allclose(pval_orig, pval_new, atol=1e-6), f"P-values mismatch:\nOriginal: {pval_orig}\nNew: {pval_new}"
+    assert np.allclose(pval_orig, pval_new, atol=1e-6), (
+        f"P-values mismatch:\nOriginal: {pval_orig}\nNew: {pval_new}"
+    )
 
     # Compare ANOVA table values (ignoring index differences)
     table_orig_values = table_orig.to_numpy()
     table_new_values = table_new.to_numpy()
 
-    assert np.allclose(table_orig_values, table_new_values, atol=1e-6, equal_nan=True), f"ANOVA tables differ:\nOriginal:\n{table_orig}\nNew:\n{table_new}"
+    assert np.allclose(
+        table_orig_values, table_new_values, atol=1e-6, equal_nan=True
+    ), f"ANOVA tables differ:\nOriginal:\n{table_orig}\nNew:\n{table_new}"
+
 
 def test_circ_anova():
     """Test the Circular ANOVA (F-test & LRT) for multiple samples."""
@@ -594,28 +668,40 @@ def test_circ_anova():
     result_f = circ_anova(samples, method="F-test")
     assert "statistic" in result_f, "F-test did not return a statistic"
     assert "p_value" in result_f, "F-test did not return a p-value"
-    assert result_f["p_value"] >= 0 and result_f["p_value"] <= 1, "F-test p-value out of range"
-    assert result_f["df"] == (2, 147, 149), f"F-test degrees of freedom mismatch: {result_f['df']}"
-    
+    assert result_f["p_value"] >= 0 and result_f["p_value"] <= 1, (
+        "F-test p-value out of range"
+    )
+    assert result_f["df"] == (2, 147, 149), (
+        f"F-test degrees of freedom mismatch: {result_f['df']}"
+    )
+
     # Run Likelihood Ratio Test (LRT)
     result_lrt = circ_anova(samples, method="LRT")
     assert "statistic" in result_lrt, "LRT did not return a statistic"
     assert "p_value" in result_lrt, "LRT did not return a p-value"
-    assert result_lrt["p_value"] >= 0 and result_lrt["p_value"] <= 1, "LRT p-value out of range"
+    assert result_lrt["p_value"] >= 0 and result_lrt["p_value"] <= 1, (
+        "LRT p-value out of range"
+    )
     assert result_lrt["df"] == 2, f"LRT degrees of freedom mismatch: {result_lrt['df']}"
 
     # Edge case: All groups have the same mean direction
     identical_group = np.random.vonmises(mu=0, kappa=5, size=50)
     result_identical = circ_anova([identical_group] * 3, method="F-test")
-    assert result_identical["p_value"] > 0.05, "F-test should not reject H0 for identical groups"
+    assert result_identical["p_value"] > 0.05, (
+        "F-test should not reject H0 for identical groups"
+    )
 
     # Edge case: Small sample sizes
     small_group1 = np.random.vonmises(mu=0, kappa=5, size=5)
     small_group2 = np.random.vonmises(mu=np.pi / 4, kappa=5, size=5)
     small_group3 = np.random.vonmises(mu=np.pi / 2, kappa=5, size=5)
 
-    result_small = circ_anova([small_group1, small_group2, small_group3], method="F-test")
-    assert result_small["p_value"] >= 0 and result_small["p_value"] <= 1, "Small-sample p-value out of range"
+    result_small = circ_anova(
+        [small_group1, small_group2, small_group3], method="F-test"
+    )
+    assert result_small["p_value"] >= 0 and result_small["p_value"] <= 1, (
+        "Small-sample p-value out of range"
+    )
 
     # Invalid method check
     with pytest.raises(ValueError, match="Invalid method. Choose 'F-test' or 'LRT'."):
@@ -636,6 +722,7 @@ def test_equal_median_identical_samples():
     assert result["reject"] is np.False_
     assert not np.isnan(result["common_median"])
 
+
 def test_equal_median_different_samples():
     """Test if the test correctly rejects H₀ when groups have different medians."""
     alpha1 = np.array([0.1, 0.2, 0.3, 1.5, 1.6])
@@ -645,6 +732,7 @@ def test_equal_median_different_samples():
     result = common_median_test([alpha1, alpha2, alpha3])
     assert result["reject"] is np.True_
     assert np.isnan(result["common_median"])
+
 
 def test_equal_median_large_sample():
     """Test the function on large sample sizes with similar medians."""
@@ -656,6 +744,7 @@ def test_equal_median_large_sample():
     result = common_median_test([alpha1, alpha2, alpha3])
     assert result["reject"] is np.False_
     assert not np.isnan(result["common_median"])
+
 
 def test_equal_median_small_sample():
     """Test if the function handles small sample sizes correctly."""


### PR DESCRIPTION
An implementation of the Angular Randomisation test (ART), which was originally introduced by Ali & Abushilah (2022) and later validated by Ruxton, Malkemper & Landler (2023). Their validation found that ART generally outperforms traditional two-sample tests like Watson's U² and Watson-Wheeler tests, although not for all use cases.

I've added a cell to the `hypothesis` notebook, although I have not implemented a proper test yet.

References:

> Ali, A. J., & Abushilah, S. F. (2022). Distribution-free two-sample homogeneity test for circular data based on geodesic distance. Int. J. Nonlinear Anal. Appl., 13, 2703-2711.

> Ruxton, G. D., Malkemper, E. P., & Landler, L. (2023). Evaluating the power of a recent method for comparing two circular distributions: an alternative to the Watson U² test. Scientific Reports, 13, 10007.